### PR TITLE
fix(chat): address PR #3 review — observer thrashing, type safety, stale DOM

### DIFF
--- a/docs/project/versions/frontend/CHANGELOG.md
+++ b/docs/project/versions/frontend/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.7] - 2026-03-10
+
+### Added
+- Fix infinite scroll observer thrashing, type safety, and stale DOM ref
+
+
 ## [0.11.5] - 2025-12-29
 
 ### Fixed

--- a/docs/project/versions/frontend/CHANGELOG.md
+++ b/docs/project/versions/frontend/CHANGELOG.md
@@ -9,9 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.7] - 2026-03-10
 
-### Added
-- Fix infinite scroll observer thrashing, type safety, and stale DOM ref
+### Fixed
+- fix(chat): eliminate IntersectionObserver thrashing on every streaming message
+- fix(chat): add isConnected guard on scroll container in rAF callback
+- fix(chat): set hasMoreMessages based on restored count (>= 50)
+- fix(chat): always skip first IntersectionObserver callback to prevent double-load
+- fix(types): add generic type parameter to replayDeepEvents for type safety
 
+## [0.11.6] - 2026-03-04
+
+### Added
+- feat(chat): infinite scroll for chat message history
+- feat(chat): deep agent accordion state persistence on chat restore
+- refactor(utils): extract parseBackendMessage and replayDeepEvents to messageParser.ts
 
 ## [0.11.5] - 2025-12-29
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.0",
-    "@rollup/rollup-darwin-arm64": "^4.59.0",
     "@tanstack/react-query": "^5.10.0",
     "@tanstack/react-query-devtools": "^5.10.0",
     "@types/react-syntax-highlighter": "^15.5.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "financial-agent-frontend",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "type": "module",
   "description": "AI-Enhanced Financial Analysis Platform Frontend",
   "scripts": {
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.0",
+    "@rollup/rollup-darwin-arm64": "^4.59.0",
     "@tanstack/react-query": "^5.10.0",
     "@tanstack/react-query-devtools": "^5.10.0",
     "@types/react-syntax-highlighter": "^15.5.10",

--- a/frontend/src/components/EnhancedChatInterface.tsx
+++ b/frontend/src/components/EnhancedChatInterface.tsx
@@ -92,6 +92,11 @@ export function EnhancedChatInterface() {
 
   const { messages, setMessages, chatId, setChatId } = useChatManager();
 
+  // Ref for messages.length — avoids stale closure in handleLoadMore without
+  // adding messages.length to its dependency array (which causes observer thrashing)
+  const messagesLengthRef = useRef(0);
+  messagesLengthRef.current = messages.length;
+
   // Chat restoration hook
   const { restoreChat } = useChatRestoration({
     setMessages,
@@ -285,7 +290,7 @@ export function EnhancedChatInterface() {
         deepDispatch({ type: "RESET" });
 
         const restoredMessages = await restoreChat(chatId);
-        setHasMoreMessages(true);
+        setHasMoreMessages((restoredMessages?.length ?? 0) >= 50);
 
         // Replay deep events from the most recent deep analysis message
         if (restoredMessages) {
@@ -326,7 +331,7 @@ export function EnhancedChatInterface() {
 
     try {
       const { chatService } = await import("../services/api");
-      const currentOffset = messages.length;
+      const currentOffset = messagesLengthRef.current;
       const chatDetail = await chatService.getChatDetail(
         chatId,
         50,
@@ -359,7 +364,7 @@ export function EnhancedChatInterface() {
       // Restore scroll position AFTER React renders new messages (double rAF ensures DOM flush)
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          if (scrollContainer) {
+          if (scrollContainer?.isConnected) {
             const newScrollHeight = scrollContainer.scrollHeight;
             scrollContainer.scrollTop += newScrollHeight - prevScrollHeight;
           }
@@ -370,14 +375,7 @@ export function EnhancedChatInterface() {
     } finally {
       setIsLoadingMore(false);
     }
-  }, [
-    chatId,
-    messages.length,
-    isLoadingMore,
-    setMessages,
-    deepDispatch,
-    deepState.status,
-  ]);
+  }, [chatId, isLoadingMore, setMessages, deepDispatch, deepState.status]);
 
   return (
     <div className="bg-white overflow-hidden max-h-screen">

--- a/frontend/src/components/chat/ChatMessages.tsx
+++ b/frontend/src/components/chat/ChatMessages.tsx
@@ -34,7 +34,9 @@ const formatTimestamp = (timestamp: string) => {
 };
 
 // Parse thinking content from message
-const parseThinkingContent = (content: string): { thinking: string[]; mainContent: string } => {
+const parseThinkingContent = (
+  content: string,
+): { thinking: string[]; mainContent: string } => {
   const thinkingRegex = /<thinking>(.*?)<\/thinking>/gs;
   const thinkingMatches: string[] = [];
   let match;
@@ -44,7 +46,7 @@ const parseThinkingContent = (content: string): { thinking: string[]; mainConten
   }
 
   // Remove thinking tags from main content
-  const mainContent = content.replace(thinkingRegex, '').trim();
+  const mainContent = content.replace(thinkingRegex, "").trim();
 
   return {
     thinking: thinkingMatches,
@@ -53,7 +55,10 @@ const parseThinkingContent = (content: string): { thinking: string[]; mainConten
 };
 
 // Memoized message component to prevent re-renders
-const MessageBubble = React.memo<{ msg: ChatMessage; t: (key: string, options?: Record<string, unknown>) => string }>(({ msg, t }) => {
+const MessageBubble = React.memo<{
+  msg: ChatMessage;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}>(({ msg, t }) => {
   // Memoize thinking content parsing to avoid re-parsing on every render
   const { thinking, mainContent } = useMemo(() => {
     return msg.role === "assistant"
@@ -76,15 +81,31 @@ const MessageBubble = React.memo<{ msg: ChatMessage; t: (key: string, options?: 
         {thinking.length > 0 && (
           <details className="mb-3 group">
             <summary className="cursor-pointer select-none px-3 py-2 flex items-center gap-2 bg-blue-50/60 hover:bg-blue-50 rounded-lg border border-blue-200/50 transition-colors">
-              <svg className="w-4 h-4 text-blue-600 flex-shrink-0 group-open:rotate-90 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              <svg
+                className="w-4 h-4 text-blue-600 flex-shrink-0 group-open:rotate-90 transition-transform"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
               </svg>
-              <span className="text-xs font-medium text-blue-700">{t('chat:message.thinkingProcess')}</span>
-              <span className="text-xs text-blue-600/70 ml-auto">{t('chat:message.thinkingChars', { count: thinking.join('').length })}</span>
+              <span className="text-xs font-medium text-blue-700">
+                {t("chat:message.thinkingProcess")}
+              </span>
+              <span className="text-xs text-blue-600/70 ml-auto">
+                {t("chat:message.thinkingChars", {
+                  count: thinking.join("").length,
+                })}
+              </span>
             </summary>
             <div className="mt-2 p-3 bg-gray-50 rounded-lg border border-gray-200">
               <pre className="text-xs text-gray-600 whitespace-pre-wrap font-mono leading-relaxed overflow-x-auto">
-{thinking.join('\n\n')}
+                {thinking.join("\n\n")}
               </pre>
             </div>
           </details>
@@ -238,7 +259,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
   sortOrder = "oldest", // Default to oldest first (chronological) for chat messages
   deepAccordion,
 }) => {
-  const { t } = useTranslation(['chat', 'common']);
+  const { t } = useTranslation(["chat", "common"]);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const lastUserMessageRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -256,7 +277,9 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 
     // Detect chat change by checking if first message ID changed
     const firstMessageId = String(messages[0]._id || messages[0].timestamp);
-    const isChatChange = firstMessageIdRef.current !== null && firstMessageIdRef.current !== firstMessageId;
+    const isChatChange =
+      firstMessageIdRef.current !== null &&
+      firstMessageIdRef.current !== firstMessageId;
 
     if (isChatChange) {
       lastScrolledUserMessageRef.current = null;
@@ -278,12 +301,13 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
       if (lastScrolledUserMessageRef.current === null) {
         const SCROLL_DELAY_MS = 100;
         const timeoutId = setTimeout(() => {
-          const messagesContainer = messagesEndRef.current?.closest('.overflow-y-auto');
+          const messagesContainer =
+            messagesEndRef.current?.closest(".overflow-y-auto");
           if (messagesContainer) {
             messagesContainer.scrollTop = 0;
           }
         }, SCROLL_DELAY_MS);
-        lastScrolledUserMessageRef.current = 'no-user-messages';
+        lastScrolledUserMessageRef.current = "no-user-messages";
 
         return () => clearTimeout(timeoutId);
       }
@@ -296,15 +320,22 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
     );
 
     // Check if this is a chat restoration (no previous scroll tracking)
-    const isRestoringChat = lastScrolledUserMessageRef.current === null && messages.length > 1;
+    const isRestoringChat =
+      lastScrolledUserMessageRef.current === null && messages.length > 1;
 
     if (isRestoringChat) {
       // On chat restoration: scroll to last USER message to see what was asked
-      lastUserMessageRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      lastUserMessageRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
       lastScrolledUserMessageRef.current = userMessageId;
     } else if (lastScrolledUserMessageRef.current !== userMessageId) {
       // On new user message: scroll to show that message at the start
-      lastUserMessageRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      lastUserMessageRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
       lastScrolledUserMessageRef.current = userMessageId;
     }
   }, [messages]);
@@ -322,14 +353,14 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
 
-    // Skip the initial intersection report that fires on observe()
+    // Always skip the synthetic first callback that fires on observe()
     let isFirstCallback = true;
 
     const observer = new IntersectionObserver(
       (entries) => {
         if (isFirstCallback) {
           isFirstCallback = false;
-          if (!entries[0].isIntersecting) return;
+          return;
         }
         if (entries[0].isIntersecting && !isLoadingMoreRef.current) {
           if (onLoadMoreRef.current) void onLoadMoreRef.current();
@@ -340,14 +371,16 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [chatId, hasMore, onLoadMore]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onLoadMore captured via onLoadMoreRef
+  }, [chatId, hasMore]);
 
   // Memoize filtered and sorted messages to avoid re-computing on every render
   const visibleMessages = useMemo(() => {
-    const filtered = messages.filter(msg =>
-      // Skip empty assistant messages (streaming placeholders)
-      // BUT keep tool progress messages even if they have empty content
-      msg.role !== "assistant" || msg.content.trim() || msg.tool_progress
+    const filtered = messages.filter(
+      (msg) =>
+        // Skip empty assistant messages (streaming placeholders)
+        // BUT keep tool progress messages even if they have empty content
+        msg.role !== "assistant" || msg.content.trim() || msg.tool_progress,
     );
 
     // Sort messages based on sortOrder prop
@@ -374,7 +407,10 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
   }, [visibleMessages]);
 
   return (
-    <div data-chat-scroll className="flex-1 overflow-y-auto px-4 py-4 space-y-4 min-h-0">
+    <div
+      data-chat-scroll
+      className="flex-1 overflow-y-auto px-4 py-4 space-y-4 min-h-0"
+    >
       {/* Chat ID Display - Debug info */}
       {chatId && (
         <div className="flex justify-center mb-2">
@@ -431,7 +467,9 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
           <div className="w-full bg-white text-gray-900 px-4 py-3 rounded-lg border border-gray-200 shadow-sm">
             <div className="flex items-center gap-3">
               <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
-              <span className="text-sm font-medium">{t('chat:message.analyzing')}</span>
+              <span className="text-sm font-medium">
+                {t("chat:message.analyzing")}
+              </span>
             </div>
           </div>
         </div>

--- a/frontend/src/utils/__tests__/messageParser.test.ts
+++ b/frontend/src/utils/__tests__/messageParser.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Unit tests for messageParser utility.
+ *
+ * Tests parseBackendMessage conversion and replayDeepEvents dispatch logic.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { parseBackendMessage, replayDeepEvents } from "../messageParser";
+import type { ChatMessage, DeepStreamEvent } from "../../types/api";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBackendMsg(overrides: Record<string, unknown> = {}) {
+  return {
+    role: "assistant",
+    content: "hello",
+    timestamp: "2026-03-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeChatMsg(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    role: "assistant",
+    content: "hello",
+    timestamp: "2026-03-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const sampleDeepEvent: DeepStreamEvent = {
+  type: "deep_start",
+  seq: 1,
+  timestamp: "2026-03-10T00:00:00Z",
+  symbol: "AAPL",
+  subagent_names: ["technical"],
+  enable_debate: false,
+};
+
+// ---------------------------------------------------------------------------
+// parseBackendMessage
+// ---------------------------------------------------------------------------
+
+describe("parseBackendMessage", () => {
+  it("maps role, content, and timestamp", () => {
+    const result = parseBackendMessage(makeBackendMsg());
+
+    expect(result.role).toBe("assistant");
+    expect(result.content).toBe("hello");
+    expect(result.timestamp).toBe("2026-03-10T00:00:00Z");
+  });
+
+  it("passes through tool_call", () => {
+    const toolCall = { tool_name: "get_price", input: {}, output: "100" };
+    const result = parseBackendMessage(makeBackendMsg({ tool_call: toolCall }));
+
+    expect(result.tool_call).toEqual(toolCall);
+  });
+
+  it("extracts deep_events from metadata.raw_data", () => {
+    const msg = makeBackendMsg({
+      metadata: {
+        raw_data: {
+          deep_events: [sampleDeepEvent],
+          other_key: "keep",
+        },
+      },
+    });
+
+    const result = parseBackendMessage(msg);
+
+    expect(result.deep_events).toEqual([sampleDeepEvent]);
+    expect(result.analysis_data).toEqual({ other_key: "keep" });
+  });
+
+  it("filters deep_events out of analysis_data", () => {
+    const msg = makeBackendMsg({
+      metadata: {
+        raw_data: {
+          deep_events: [sampleDeepEvent],
+        },
+      },
+    });
+
+    const result = parseBackendMessage(msg);
+
+    expect(result.deep_events).toEqual([sampleDeepEvent]);
+    // Only deep_events in raw_data → analysis_data should be undefined
+    expect(result.analysis_data).toBeUndefined();
+  });
+
+  it("falls back to metadata as analysis_data when no raw_data", () => {
+    const msg = makeBackendMsg({
+      metadata: { summary: "bullish" },
+    });
+
+    const result = parseBackendMessage(msg);
+
+    expect(result.analysis_data).toEqual({ summary: "bullish" });
+    expect(result.deep_events).toBeUndefined();
+  });
+
+  it("returns undefined analysis_data when metadata is empty", () => {
+    const result = parseBackendMessage(makeBackendMsg({ metadata: {} }));
+
+    expect(result.analysis_data).toBeUndefined();
+  });
+
+  it("returns undefined analysis_data when no metadata", () => {
+    const result = parseBackendMessage(makeBackendMsg());
+
+    expect(result.analysis_data).toBeUndefined();
+    expect(result.deep_events).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// replayDeepEvents
+// ---------------------------------------------------------------------------
+
+describe("replayDeepEvents", () => {
+  it("dispatches actions for the most recent message with deep_events", () => {
+    const dispatch = vi.fn();
+    const mapper = (event: DeepStreamEvent) => ({ type: "ACTION", event });
+
+    const messages: ChatMessage[] = [
+      makeChatMsg({ deep_events: [sampleDeepEvent] }),
+      makeChatMsg({ content: "later message" }),
+    ];
+
+    const result = replayDeepEvents(messages, mapper, dispatch);
+
+    // Should find the FIRST message (iterating backward, the last with events)
+    // Actually it iterates backward and picks the first one with deep_events
+    // messages[1] has no events, messages[0] has events
+    expect(result).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "ACTION",
+      event: sampleDeepEvent,
+    });
+  });
+
+  it("picks the most recent message with deep_events (backward iteration)", () => {
+    const dispatch = vi.fn();
+    const oldEvent: DeepStreamEvent = {
+      ...sampleDeepEvent,
+      symbol: "OLD",
+    };
+    const newEvent: DeepStreamEvent = {
+      ...sampleDeepEvent,
+      symbol: "NEW",
+    };
+    const mapper = (event: DeepStreamEvent) => ({ type: "ACTION", event });
+
+    const messages: ChatMessage[] = [
+      makeChatMsg({ deep_events: [oldEvent] }),
+      makeChatMsg({ content: "middle" }),
+      makeChatMsg({ deep_events: [newEvent] }),
+    ];
+
+    replayDeepEvents(messages, mapper, dispatch);
+
+    // Should dispatch newEvent (index 2), not oldEvent (index 0)
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "ACTION",
+      event: newEvent,
+    });
+  });
+
+  it("returns false when no messages have deep_events", () => {
+    const dispatch = vi.fn();
+    const mapper = () => null;
+
+    const messages: ChatMessage[] = [makeChatMsg(), makeChatMsg()];
+
+    const result = replayDeepEvents(messages, mapper, dispatch);
+
+    expect(result).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("returns false when mapper returns null for all events", () => {
+    const dispatch = vi.fn();
+    const mapper = () => null;
+
+    const messages: ChatMessage[] = [
+      makeChatMsg({ deep_events: [sampleDeepEvent] }),
+    ];
+
+    const result = replayDeepEvents(messages, mapper, dispatch);
+
+    expect(result).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("returns false for empty message array", () => {
+    const dispatch = vi.fn();
+    const mapper = () => ({ type: "ACTION" });
+
+    const result = replayDeepEvents([], mapper, dispatch);
+
+    expect(result).toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("dispatches multiple events from a single message", () => {
+    const dispatch = vi.fn();
+    const event2: DeepStreamEvent = {
+      ...sampleDeepEvent,
+      seq: 2,
+      type: "deep_subagent_start",
+      subagent_name: "technical",
+      display_name: "Technical",
+      icon: "chart",
+      tool_names: ["get_price"],
+    };
+    const mapper = (event: DeepStreamEvent) => ({ type: "ACTION", event });
+
+    const messages: ChatMessage[] = [
+      makeChatMsg({ deep_events: [sampleDeepEvent, event2] }),
+    ];
+
+    const result = replayDeepEvents(messages, mapper, dispatch);
+
+    expect(result).toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves generic type safety (compile-time check)", () => {
+    // This test verifies the generic <A> works — if types don't match,
+    // TypeScript would fail to compile this file
+    type MyAction = { kind: "custom"; payload: string };
+    const dispatch = vi.fn<[MyAction], void>();
+    const mapper = (): MyAction | null => ({
+      kind: "custom",
+      payload: "test",
+    });
+
+    const messages: ChatMessage[] = [
+      makeChatMsg({ deep_events: [sampleDeepEvent] }),
+    ];
+
+    replayDeepEvents<MyAction>(messages, mapper, dispatch);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      kind: "custom",
+      payload: "test",
+    });
+  });
+});

--- a/frontend/src/utils/messageParser.ts
+++ b/frontend/src/utils/messageParser.ts
@@ -59,10 +59,10 @@ export function parseBackendMessage(msg: BackendMessage): ChatMessage {
  * Iterates backward to find the most recent message with deep_events,
  * replays all events, and returns true if any actions were dispatched.
  */
-export function replayDeepEvents(
+export function replayDeepEvents<A>(
   messages: ChatMessage[],
-  mapEventToAction: (event: DeepStreamEvent) => unknown | null,
-  dispatch: (action: unknown) => void,
+  mapEventToAction: (event: DeepStreamEvent) => A | null,
+  dispatch: (action: A) => void,
 ): boolean {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i];


### PR DESCRIPTION
## Summary
- **Fix observer thrashing**: Replace `messages.length` dep with `messagesLengthRef` in `handleLoadMore`, remove `onLoadMore` from IntersectionObserver effect deps — prevents observer rebuild on every streaming chunk
- **Fix type safety**: Add generic `<A>` to `replayDeepEvents` for compile-time action type verification
- **Fix stale DOM**: Add `isConnected` guard in scroll-restore rAF callback to prevent access after navigation
- **Fix wasted API call**: Set `hasMoreMessages` from restored count (`>= 50`) instead of unconditional `true`
- **Fix double-load**: Always skip first IntersectionObserver callback to prevent load on mount

## Test plan
- [x] TypeScript: `tsc --noEmit` — zero new errors (only pre-existing line 585 ChartPanel prop)
- [x] Vitest: 256/256 tests pass
- [x] ESLint: zero new errors in changed files
- [ ] Manual: verify infinite scroll works on chat with 50+ messages
- [ ] Manual: verify accordion state restores on chat switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)