### PR TITLE
fix: simplify welcome message and default to deep analysis mode

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "financial-agent-frontend",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "financial-agent-frontend",
-      "version": "0.11.6",
+      "version": "0.11.7",
       "dependencies": {
         "@hookform/resolvers": "^3.3.0",
         "@tanstack/react-query": "^5.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "financial-agent-frontend",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "type": "module",
   "description": "AI-Enhanced Financial Analysis Platform Frontend",
   "scripts": {

--- a/frontend/public/locales/en/chat.json
+++ b/frontend/public/locales/en/chat.json
@@ -162,16 +162,6 @@
     "creditsUnit": "credits",
     "lowBalanceWarning": "Low balance - Top up soon"
   },
-  "mode": {
-    "label": "Mode",
-    "agent": "Agent",
-    "copilot": "Copilot",
-    "deep": "Deep",
-    "locked": "Mode locked for this chat",
-    "agentDescription": "Agent mode (auto tool calling)",
-    "copilotDescription": "Copilot mode (manual tools)",
-    "deepDescription": "Deep analysis (multi-agent + debate verification)"
-  },
   "mobile": {
     "hideSidebar": "← Hide",
     "showChats": "← Chats",
@@ -234,14 +224,9 @@
     "statusFailed": "Failed"
   },
   "welcome": {
-    "title": "🎯 Welcome to Financial Agent!",
-    "firstTime": "✨ **First Time Here?**",
-    "firstTimeHint": "Click the **❓** button in the bottom-right corner for a quick interactive guide!",
-    "modesTitle": "🚀 **Three Powerful Modes to Explore:**",
-    "agentMode": "🤖 **Agent Mode** — Let AI automatically analyze and provide insights",
-    "copilotMode": "💬 **Copilot Mode** — You control, AI guides",
-    "portfolioMode": "📊 **Portfolio Tracking** — Monitor your investment performance",
-    "proTip": "💡 **Pro Tip:** Start by asking a question or searching for a stock symbol to see the magic happen!"
+    "title": "Welcome to Financial Agent",
+    "subtitle": "Ask any question about stocks, markets, or your portfolio. The agent will automatically research and analyze using multiple sources.",
+    "hint": "Try searching for a stock symbol on the right, or just ask a question below to get started."
   },
   "help": {
     "title": "How to Use Financial Agent",
@@ -257,30 +242,6 @@
       "step3Desc": "Market data, news, etc.",
       "step4": "4. Get Insights",
       "step4Desc": "Suggestions & summary"
-    },
-    "copilotMode": {
-      "title": "💬 Copilot Mode",
-      "subtitle": "Manual exploration with AI guidance",
-      "description": "You control the analysis by clicking buttons to trigger specific analyses and view charts. The AI helps you understand the results and provides context.",
-      "step1": "1. Click Analysis",
-      "step1Desc": "Choose tool button",
-      "step2": "2. View Chart",
-      "step2Desc": "Visual data display",
-      "step3": "3. AI Explains",
-      "step3Desc": "Context & insights"
-    },
-    "portfolioAgent": {
-      "title": "📊 Portfolio Agent",
-      "subtitle": "Track simulated trading performance",
-      "description": "Navigate to the Portfolio page to view your simulated holdings, transaction history, and profit/loss performance. The agent mimics real trading scenarios.",
-      "step1": "Go to Portfolio Tab",
-      "step1Desc": "Click \"Portfolio\" in the top navigation",
-      "step2": "View Holdings Dashboard",
-      "step2Desc": "See current positions and allocations",
-      "step3": "Check Transaction History",
-      "step3Desc": "Review buy/sell transactions",
-      "step4": "Analyze P&L Performance",
-      "step4Desc": "Track earnings and losses over time"
     },
     "footer": "Need more help? Contact support or check our documentation"
   }

--- a/frontend/public/locales/zh-CN/chat.json
+++ b/frontend/public/locales/zh-CN/chat.json
@@ -162,16 +162,6 @@
     "creditsUnit": "额度",
     "lowBalanceWarning": "余额不足 - 请及时充值"
   },
-  "mode": {
-    "label": "模式",
-    "agent": "代理",
-    "copilot": "助手",
-    "deep": "深度分析",
-    "locked": "此对话模式已锁定",
-    "agentDescription": "代理模式（自动调用工具）",
-    "copilotDescription": "助手模式（手动工具）",
-    "deepDescription": "深度分析模式（多智能体+辩论验证）"
-  },
   "mobile": {
     "hideSidebar": "← 隐藏",
     "showChats": "← 对话",
@@ -234,14 +224,9 @@
     "statusFailed": "失败"
   },
   "welcome": {
-    "title": "🎯 欢迎使用金融智能助手！",
-    "firstTime": "✨ **首次使用？**",
-    "firstTimeHint": "点击左下角的 **❓** 按钮查看快速交互指南！",
-    "modesTitle": "🚀 **三种强大模式供您探索：**",
-    "agentMode": "🤖 **代理模式** — 让AI自动分析并提供洞察",
-    "copilotMode": "💬 **助手模式** — 您来控制，AI来指导",
-    "portfolioMode": "📊 **投资组合追踪** — 监控您的投资表现",
-    "proTip": "💡 **小贴士：** 输入问题或搜索股票代码，即可体验神奇效果！"
+    "title": "Welcome to Financial Agent",
+    "subtitle": "Ask any question about stocks, markets, or your portfolio. The agent will automatically research and analyze using multiple sources.",
+    "hint": "Try searching for a stock symbol on the right, or just ask a question below to get started."
   },
   "help": {
     "title": "如何使用金融智能助手",
@@ -257,30 +242,6 @@
       "step3Desc": "市场数据、新闻等",
       "step4": "4. 获取洞察",
       "step4Desc": "建议和总结"
-    },
-    "copilotMode": {
-      "title": "💬 助手模式",
-      "subtitle": "AI指导下的手动探索",
-      "description": "您通过点击按钮触发特定分析和查看图表来控制分析过程。AI帮助您理解结果并提供上下文。",
-      "step1": "1. 点击分析",
-      "step1Desc": "选择工具按钮",
-      "step2": "2. 查看图表",
-      "step2Desc": "可视化数据展示",
-      "step3": "3. AI解释",
-      "step3Desc": "上下文和洞察"
-    },
-    "portfolioAgent": {
-      "title": "📊 投资组合代理",
-      "subtitle": "追踪模拟交易表现",
-      "description": "前往投资组合页面查看您的模拟持仓、交易历史和盈亏表现。代理模拟真实交易场景。",
-      "step1": "前往投资组合标签",
-      "step1Desc": "点击顶部导航中的「投资组合」",
-      "step2": "查看持仓仪表板",
-      "step2Desc": "查看当前持仓和配置",
-      "step3": "检查交易历史",
-      "step3Desc": "查看买卖交易记录",
-      "step4": "分析盈亏表现",
-      "step4Desc": "追踪一段时间内的收益和损失"
     },
     "footer": "需要更多帮助？请联系支持或查看我们的文档"
   }

--- a/frontend/src/components/EnhancedChatInterface.tsx
+++ b/frontend/src/components/EnhancedChatInterface.tsx
@@ -47,8 +47,10 @@ export function EnhancedChatInterface() {
     debug_enabled: false,
   });
 
-  // Agent mode: v3 = Agent (auto tools), v2 = Copilot (manual tools), v4-deep = Deep analysis
-  const [agentMode, setAgentMode] = useState<"v2" | "v3" | "v4-deep">("v3");
+  // Deep analysis is the default (and only) mode
+  const [agentMode, setAgentMode] = useState<"v2" | "v3" | "v4-deep">(
+    "v4-deep",
+  );
 
   // Deep agent accordion state (active when agentMode === "v4-deep")
   const { state: deepState, dispatch: deepDispatch } = useDeepAccordionState();
@@ -312,7 +314,7 @@ export function EnhancedChatInterface() {
     setDateRangeEnd("");
     setHasMoreMessages(false); // Reset pagination
     deepDispatch({ type: "RESET" }); // Reset deep accordion state
-    setAgentMode("v3"); // Reset to default agent mode
+    setAgentMode("v4-deep"); // Reset to default deep analysis mode
   }, [setMessages, setChatId, deepDispatch]);
 
   const handleLoadMore = useCallback(async () => {
@@ -463,80 +465,6 @@ export function EnhancedChatInterface() {
                   isLoadingMore={isLoadingMore}
                   deepAccordion={deepAccordionElement}
                 />
-
-                {/* Agent Mode Toggle - Only enabled when starting new chat */}
-                <div className="flex-shrink-0 px-4 py-2 border-t border-gray-100 bg-gray-50/50">
-                  <div className="flex items-center gap-3 text-sm">
-                    <span className="text-gray-600 font-medium">
-                      {t("chat:mode.label")}:
-                    </span>
-                    <button
-                      onClick={() => setAgentMode("v3")}
-                      disabled={!!chatId}
-                      className={`px-3 py-1.5 rounded-lg font-medium transition-all ${
-                        agentMode === "v3"
-                          ? "bg-gradient-to-r from-blue-500 to-indigo-500 text-white shadow-md"
-                          : "bg-white text-gray-700 hover:bg-gray-100"
-                      } ${
-                        chatId
-                          ? "opacity-50 cursor-not-allowed"
-                          : "cursor-pointer"
-                      }`}
-                      title={
-                        chatId
-                          ? t("chat:mode.locked")
-                          : t("chat:mode.agentDescription")
-                      }
-                    >
-                      🤖 {t("chat:mode.agent")}
-                    </button>
-                    <button
-                      onClick={() => setAgentMode("v2")}
-                      disabled={!!chatId}
-                      className={`px-3 py-1.5 rounded-lg font-medium transition-all ${
-                        agentMode === "v2"
-                          ? "bg-gradient-to-r from-purple-500 to-pink-500 text-white shadow-md"
-                          : "bg-white text-gray-700 hover:bg-gray-100"
-                      } ${
-                        chatId
-                          ? "opacity-50 cursor-not-allowed"
-                          : "cursor-pointer"
-                      }`}
-                      title={
-                        chatId
-                          ? t("chat:mode.locked")
-                          : t("chat:mode.copilotDescription")
-                      }
-                    >
-                      👤 {t("chat:mode.copilot")}
-                    </button>
-                    <button
-                      onClick={() => setAgentMode("v4-deep")}
-                      disabled={!!chatId}
-                      className={`px-3 py-1.5 rounded-lg font-medium transition-all ${
-                        agentMode === "v4-deep"
-                          ? "bg-gradient-to-r from-amber-500 to-orange-500 text-white shadow-md"
-                          : "bg-white text-gray-700 hover:bg-gray-100"
-                      } ${
-                        chatId
-                          ? "opacity-50 cursor-not-allowed"
-                          : "cursor-pointer"
-                      }`}
-                      title={
-                        chatId
-                          ? t("chat:mode.locked")
-                          : t("chat:mode.deepDescription")
-                      }
-                    >
-                      🔬 {t("chat:mode.deep")}
-                    </button>
-                    {chatId && (
-                      <span className="ml-auto text-xs text-gray-500 italic">
-                        {t("chat:mode.locked")}
-                      </span>
-                    )}
-                  </div>
-                </div>
 
                 <ChatInput
                   message={message}

--- a/frontend/src/components/HelpModal.tsx
+++ b/frontend/src/components/HelpModal.tsx
@@ -1,22 +1,22 @@
-import type { KeyboardEvent } from 'react'
-import { useTranslation } from 'react-i18next'
-import { X, Bot, MessageSquare, TrendingUp, ArrowRight, ChevronDown } from 'lucide-react'
+import type { KeyboardEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { X, Bot, ArrowRight } from "lucide-react";
 
 interface HelpModalProps {
-  isOpen: boolean
-  onClose: () => void
+  isOpen: boolean;
+  onClose: () => void;
 }
 
 export default function HelpModal({ isOpen, onClose }: HelpModalProps) {
-  const { t } = useTranslation('chat')
+  const { t } = useTranslation("chat");
 
-  if (!isOpen) return null
+  if (!isOpen) return null;
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      onClose()
+    if (e.key === "Escape") {
+      onClose();
     }
-  }
+  };
 
   return (
     /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
@@ -38,7 +38,9 @@ export default function HelpModal({ isOpen, onClose }: HelpModalProps) {
         {/* eslint-enable jsx-a11y/no-static-element-interactions */}
         {/* Header */}
         <div className="sticky top-0 bg-gradient-to-r from-blue-500 to-indigo-500 text-white p-6 rounded-t-2xl flex justify-between items-center">
-          <h2 id="help-modal-title" className="text-2xl font-bold">{t('help.title')}</h2>
+          <h2 id="help-modal-title" className="text-2xl font-bold">
+            {t("help.title")}
+          </h2>
           <button
             onClick={onClose}
             className="text-white hover:bg-white/20 rounded-lg p-2 transition-colors"
@@ -57,13 +59,17 @@ export default function HelpModal({ isOpen, onClose }: HelpModalProps) {
                 <Bot className="w-6 h-6" />
               </div>
               <div>
-                <h3 className="text-xl font-bold text-blue-900">{t('help.agentMode.title')}</h3>
-                <p className="text-sm text-blue-700">{t('help.agentMode.subtitle')}</p>
+                <h3 className="text-xl font-bold text-blue-900">
+                  {t("help.agentMode.title")}
+                </h3>
+                <p className="text-sm text-blue-700">
+                  {t("help.agentMode.subtitle")}
+                </p>
               </div>
             </div>
 
             <p className="text-gray-700 mb-4">
-              {t('help.agentMode.description')}
+              {t("help.agentMode.description")}
             </p>
 
             {/* Flow Diagram */}
@@ -71,135 +77,38 @@ export default function HelpModal({ isOpen, onClose }: HelpModalProps) {
               <div className="flex items-center justify-between text-sm">
                 <div className="flex-1 text-center">
                   <div className="bg-blue-500 text-white rounded-lg py-2 px-3 mb-1 font-medium">
-                    {t('help.agentMode.step1')}
+                    {t("help.agentMode.step1")}
                   </div>
-                  <p className="text-xs text-gray-600">{t('help.agentMode.step1Desc')}</p>
+                  <p className="text-xs text-gray-600">
+                    {t("help.agentMode.step1Desc")}
+                  </p>
                 </div>
                 <ArrowRight className="w-5 h-5 text-blue-500 mx-2 flex-shrink-0" />
                 <div className="flex-1 text-center">
                   <div className="bg-blue-500 text-white rounded-lg py-2 px-3 mb-1 font-medium">
-                    {t('help.agentMode.step2')}
+                    {t("help.agentMode.step2")}
                   </div>
-                  <p className="text-xs text-gray-600">{t('help.agentMode.step2Desc')}</p>
+                  <p className="text-xs text-gray-600">
+                    {t("help.agentMode.step2Desc")}
+                  </p>
                 </div>
                 <ArrowRight className="w-5 h-5 text-blue-500 mx-2 flex-shrink-0" />
                 <div className="flex-1 text-center">
                   <div className="bg-blue-500 text-white rounded-lg py-2 px-3 mb-1 font-medium">
-                    {t('help.agentMode.step3')}
+                    {t("help.agentMode.step3")}
                   </div>
-                  <p className="text-xs text-gray-600">{t('help.agentMode.step3Desc')}</p>
+                  <p className="text-xs text-gray-600">
+                    {t("help.agentMode.step3Desc")}
+                  </p>
                 </div>
                 <ArrowRight className="w-5 h-5 text-blue-500 mx-2 flex-shrink-0" />
                 <div className="flex-1 text-center">
                   <div className="bg-blue-500 text-white rounded-lg py-2 px-3 mb-1 font-medium">
-                    {t('help.agentMode.step4')}
+                    {t("help.agentMode.step4")}
                   </div>
-                  <p className="text-xs text-gray-600">{t('help.agentMode.step4Desc')}</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Copilot Mode Section */}
-          <div className="bg-gradient-to-br from-purple-50 to-purple-100 rounded-xl p-6 border-l-4 border-purple-500 shadow-lg">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="bg-purple-500 text-white p-3 rounded-lg">
-                <MessageSquare className="w-6 h-6" />
-              </div>
-              <div>
-                <h3 className="text-xl font-bold text-purple-900">{t('help.copilotMode.title')}</h3>
-                <p className="text-sm text-purple-700">{t('help.copilotMode.subtitle')}</p>
-              </div>
-            </div>
-
-            <p className="text-gray-700 mb-4">
-              {t('help.copilotMode.description')}
-            </p>
-
-            {/* Flow Diagram */}
-            <div className="bg-white/60 backdrop-blur-sm rounded-lg p-4 border border-purple-200">
-              <div className="flex items-center justify-between text-sm">
-                <div className="flex-1 text-center">
-                  <div className="bg-purple-500 text-white rounded-lg py-2 px-3 mb-1 font-medium">
-                    {t('help.copilotMode.step1')}
-                  </div>
-                  <p className="text-xs text-gray-600">{t('help.copilotMode.step1Desc')}</p>
-                </div>
-                <ArrowRight className="w-5 h-5 text-purple-500 mx-2 flex-shrink-0" />
-                <div className="flex-1 text-center">
-                  <div className="bg-purple-500 text-white rounded-lg py-2 px-3 mb-1 font-medium">
-                    {t('help.copilotMode.step2')}
-                  </div>
-                  <p className="text-xs text-gray-600">{t('help.copilotMode.step2Desc')}</p>
-                </div>
-                <ArrowRight className="w-5 h-5 text-purple-500 mx-2 flex-shrink-0" />
-                <div className="flex-1 text-center">
-                  <div className="bg-purple-500 text-white rounded-lg py-2 px-3 mb-1 font-medium">
-                    {t('help.copilotMode.step3')}
-                  </div>
-                  <p className="text-xs text-gray-600">{t('help.copilotMode.step3Desc')}</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Portfolio Agent Section */}
-          <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-xl p-6 border-l-4 border-green-500 shadow-lg">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="bg-green-500 text-white p-3 rounded-lg">
-                <TrendingUp className="w-6 h-6" />
-              </div>
-              <div>
-                <h3 className="text-xl font-bold text-green-900">{t('help.portfolioAgent.title')}</h3>
-                <p className="text-sm text-green-700">{t('help.portfolioAgent.subtitle')}</p>
-              </div>
-            </div>
-
-            <p className="text-gray-700 mb-4">
-              {t('help.portfolioAgent.description')}
-            </p>
-
-            {/* Flow Diagram */}
-            <div className="bg-white/60 backdrop-blur-sm rounded-lg p-4 border border-green-200">
-              <div className="space-y-3">
-                <div className="flex items-start gap-3">
-                  <div className="bg-green-500 text-white rounded-full w-8 h-8 flex items-center justify-center flex-shrink-0 font-bold">
-                    1
-                  </div>
-                  <div className="flex-1">
-                    <p className="font-medium text-gray-800">{t('help.portfolioAgent.step1')}</p>
-                    <p className="text-xs text-gray-600">{t('help.portfolioAgent.step1Desc')}</p>
-                  </div>
-                </div>
-                <ChevronDown className="w-5 h-5 text-green-500 mx-auto" />
-                <div className="flex items-start gap-3">
-                  <div className="bg-green-500 text-white rounded-full w-8 h-8 flex items-center justify-center flex-shrink-0 font-bold">
-                    2
-                  </div>
-                  <div className="flex-1">
-                    <p className="font-medium text-gray-800">{t('help.portfolioAgent.step2')}</p>
-                    <p className="text-xs text-gray-600">{t('help.portfolioAgent.step2Desc')}</p>
-                  </div>
-                </div>
-                <ChevronDown className="w-5 h-5 text-green-500 mx-auto" />
-                <div className="flex items-start gap-3">
-                  <div className="bg-green-500 text-white rounded-full w-8 h-8 flex items-center justify-center flex-shrink-0 font-bold">
-                    3
-                  </div>
-                  <div className="flex-1">
-                    <p className="font-medium text-gray-800">{t('help.portfolioAgent.step3')}</p>
-                    <p className="text-xs text-gray-600">{t('help.portfolioAgent.step3Desc')}</p>
-                  </div>
-                </div>
-                <ChevronDown className="w-5 h-5 text-green-500 mx-auto" />
-                <div className="flex items-start gap-3">
-                  <div className="bg-green-500 text-white rounded-full w-8 h-8 flex items-center justify-center flex-shrink-0 font-bold">
-                    4
-                  </div>
-                  <div className="flex-1">
-                    <p className="font-medium text-gray-800">{t('help.portfolioAgent.step4')}</p>
-                    <p className="text-xs text-gray-600">{t('help.portfolioAgent.step4Desc')}</p>
-                  </div>
+                  <p className="text-xs text-gray-600">
+                    {t("help.agentMode.step4Desc")}
+                  </p>
                 </div>
               </div>
             </div>
@@ -208,12 +117,10 @@ export default function HelpModal({ isOpen, onClose }: HelpModalProps) {
 
         {/* Footer */}
         <div className="bg-gray-50 p-4 rounded-b-2xl text-center">
-          <p className="text-sm text-gray-600">
-            {t('help.footer')}
-          </p>
+          <p className="text-sm text-gray-600">{t("help.footer")}</p>
         </div>
       </div>
       {/* eslint-enable jsx-a11y/no-noninteractive-element-interactions */}
     </div>
-  )
+  );
 }

--- a/frontend/src/components/chat/useChatManager.ts
+++ b/frontend/src/components/chat/useChatManager.ts
@@ -13,28 +13,23 @@ import type { ChatMessage } from "../../types/api";
 export const useChatManager = () => {
   const { t, i18n } = useTranslation("chat");
 
-  const createWelcomeMessage = useCallback((): ChatMessage => ({
-    role: "assistant",
-    content: `${t("welcome.title")}
+  const createWelcomeMessage = useCallback(
+    (): ChatMessage => ({
+      role: "assistant",
+      content: `${t("welcome.title")}\n\n${t("welcome.subtitle")}\n\n${t("welcome.hint")}`,
+      timestamp: new Date().toISOString(),
+    }),
+    [t],
+  );
 
-${t("welcome.firstTime")}
-${t("welcome.firstTimeHint")}
-
-${t("welcome.modesTitle")}
-${t("welcome.agentMode")}
-${t("welcome.copilotMode")}
-${t("welcome.portfolioMode")}
-
-💡 ${t("welcome.proTip")}`,
-    timestamp: new Date().toISOString(),
-  }), [t]);
-
-  const [messages, setMessages] = useState<ChatMessage[]>(() => [createWelcomeMessage()]);
+  const [messages, setMessages] = useState<ChatMessage[]>(() => [
+    createWelcomeMessage(),
+  ]);
   const [chatId, setChatId] = useState<string | null>(null);
 
   // Update welcome message when language changes (only if it's the only message)
   useEffect(() => {
-    setMessages(prev => {
+    setMessages((prev) => {
       // Only update if there's just the welcome message (no chat history)
       if (prev.length === 1 && prev[0].role === "assistant") {
         return [createWelcomeMessage()];


### PR DESCRIPTION
## Summary

Simplifies the welcome message and removes mode selection UI, defaulting to deep analysis mode.

## Changes

- Simplified welcome message to 3 clean lines (title, subtitle, hint) — no emojis, no Chinese text, no mode descriptions
- Removed the 3-button mode toggle UI (Agent/Copilot/Deep) from the chat interface
- Defaulted `agentMode` to `"v4-deep"` (deep analysis) everywhere
- Cleaned up dead `mode.*` translation keys from both EN and zh-CN locale files
- Removed Copilot and Portfolio sections from HelpModal, along with unused imports
- Bumped frontend version to `0.11.7`

## Notes

Kept `agentMode` state for backward compatibility with backend API contract and chat restoration.

Closes #7